### PR TITLE
Fix IsRrreRunning method not taking 64-bit executable into account

### DIFF
--- a/sample-c/src/utils.c
+++ b/sample-c/src/utils.c
@@ -34,5 +34,5 @@ BOOL is_process_running(const TCHAR* name)
 
 BOOL is_r3e_running()
 {
-    return is_process_running(TEXT("RRRE.exe"));
+    return is_process_running(TEXT("RRRE.exe")) || is_process_running(TEXT("RRRE64.exe"));
 }

--- a/sample-csharp/src/Utilities.cs
+++ b/sample-csharp/src/Utilities.cs
@@ -17,7 +17,7 @@ namespace R3E
 
         public static bool IsRrreRunning()
         {
-            return Process.GetProcessesByName("RRRE").Length > 0;
+            return Process.GetProcessesByName("RRRE").Length > 0 || Process.GetProcessesByName("RRRE64").Length > 0;
         }
     }
 }


### PR DESCRIPTION
Executable name is different on 64-bit system, IsRrreRunning() didn't take that into account yet. 

Also fixes #4 